### PR TITLE
A few enhancements to the Helidon MP client generator 

### DIFF
--- a/bin/utils/helidon-test-petstore-e2e.sh
+++ b/bin/utils/helidon-test-petstore-e2e.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+#
+# A script to test all Helidon generators end-to-end
+#
+
+executable="./modules/openapi-generator-cli/target/openapi-generator-cli.jar"
+logfile="/tmp/helidon-test-petstore-e2e-output.log"
+#apifile="/tmp/petstore.yaml"
+project="/tmp/openapi-generator-petstore"
+apifile="modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml"
+
+function help() {
+  echo "$0 [generator]"
+  echo "If no generator specified, all Helidon generators found are tested"
+  exit 0
+}
+
+function main() {
+#setup
+
+  if [ -z ${generator} ]; then
+    # Find and test all Helidon generators
+    for generator in $(java -jar ${executable} list --short | sed -e 's/,/\'$'\n''/g' | grep helidon)
+    do
+      verify ${generator}
+    done
+  else
+    verify ${generator}
+  fi
+}
+
+function verify() {
+  echo "Using ${1}"
+  
+  echo "Generating project from ${apifile} ..."
+  if eval java -jar ${executable} generate -i ${apifile} -g ${1} -o ${project} > ${logfile} 2>&1; then
+    echo "Project generated successfully using ${1}"
+  else
+    echo "ERROR: Failed to run '${1}' generator. The command was:"
+    echo "java -jar ${executable} generate -i ${apifile} -g ${1} -o ${project}"
+    echo "ERROR: The output of the command was:"
+    cat ${logfile}
+    exit 1
+  fi
+
+  echo "Building generated project ..."
+  cd ${project} || exit 1
+  if eval mvn clean install -DskipTests; then
+    echo "Project compiled successfully"
+  else
+    echo "ERROR: Compiling project ${project}"
+    exit 2
+  fi
+
+  echo "Project location is ${project}"
+}
+
+function setup() {
+  rm -rf ${project}
+
+  echo '
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: An paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        201:
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        200:
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+' > ${apifile}
+}
+
+if [ $# -gt 0 ];
+then
+  if [ $1 = "--help" ]; then
+    help
+  fi
+  generator=$1
+fi
+
+main

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
@@ -135,7 +135,7 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
 
     @Override
     public String getHelp() {
-        return "Generates a Helidon MP or SE client";
+        return "Generates a Helidon MP client";
     }
 
     @Override

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api.mustache
@@ -15,6 +15,7 @@ import {{rootJavaEEPackage}}.ws.rs.*;
 import {{rootJavaEEPackage}}.ws.rs.core.Response;
 import {{rootJavaEEPackage}}.ws.rs.core.MediaType;
 
+import org.glassfish.jersey.media.multipart.*;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api_test.mustache
@@ -9,6 +9,7 @@ import org.junit.BeforeClass;
 import static org.junit.Assert.*;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.glassfish.jersey.media.multipart.*;
 
 import java.net.URL;
 import java.net.MalformedURLException;
@@ -57,7 +58,7 @@ public class {{classname}}Test {
     public void {{operationId}}Test() throws Exception {
         // TODO: test validations
         {{#allParams}}
-        {{^isFile}}{{{dataType}}} {{paramName}} = null;{{/isFile}}{{#isFile}}org.apache.cxf.jaxrs.ext.multipart.Attachment {{paramName}} = null;{{/isFile}}
+        {{^isFile}}{{{dataType}}} {{paramName}} = null;{{/isFile}}{{#isFile}}MultiPart {{paramName}} = null;{{/isFile}}
         {{/allParams}}
         //{{#returnType}}{{{.}}} response = {{/returnType}}client.{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
         //{{#returnType}}assertNotNull(response);{{/returnType}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/enumClass.mustache
@@ -1,22 +1,12 @@
-{{#withXml}}
-@XmlType(name="{{datatypeWithEnum}}")
-@XmlEnum({{dataType}}.class)
-{{/withXml}}
-{{^withXml}}
+{{#jsonb}}
   @JsonbTypeSerializer({{datatypeWithEnum}}.Serializer.class)
   @JsonbTypeDeserializer({{datatypeWithEnum}}.Deserializer.class)
-{{/withXml}}
-  {{>additionalEnumTypeAnnotations}}public enum {{datatypeWithEnum}} {
+{{/jsonb}}
+{{>additionalEnumTypeAnnotations}}public enum {{datatypeWithEnum}} {
 
     {{#allowableValues}}
-    {{#withXml}}
-    {{#enumVars}}@XmlEnumValue({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}) {{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
-    {{/withXml}}
-    {{^withXml}}
     {{#enumVars}}{{name}}({{dataType}}.valueOf({{{value}}})){{^-last}}, {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}
-    {{/withXml}}
     {{/allowableValues}}
-
 
     {{dataType}} value;
 
@@ -33,17 +23,7 @@
         return String.valueOf(value);
     }
 
-    {{#withXml}}
-    public static {{datatypeWithEnum}} fromValue(String v) {
-        for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
-            if (String.valueOf(b.value).equals(v)) {
-                return b;
-            }
-        }
-        {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + v + "'");{{/useNullForUnknownEnumValue}}
-    }
-    {{/withXml}}
-    {{^withXml}}
+    {{#jsonb}}
     public static final class Deserializer implements JsonbDeserializer<{{datatypeWithEnum}}> {
         @Override
         public {{datatypeWithEnum}} deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
@@ -62,5 +42,5 @@
             generator.write(obj.value);
         }
     }
-    {{/withXml}}
-  }
+    {{/jsonb}}
+}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/enumOuterClass.mustache
@@ -7,17 +7,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
  */
 {{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
-  {{#gson}}
-  {{#allowableValues}}{{#enumVars}}
-  @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
-  {{{name}}}({{{value}}}){{^-last}},
-  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
-  {{/gson}}
-  {{^gson}}
   {{#allowableValues}}{{#enumVars}}
   {{{name}}}({{{value}}}){{^-last}},
   {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
-  {{/gson}}
 
   private {{{dataType}}} value;
 
@@ -44,5 +36,4 @@ import com.fasterxml.jackson.annotation.JsonValue;
     }
     {{#useNullForUnknownEnumValue}}return null;{{/useNullForUnknownEnumValue}}{{^useNullForUnknownEnumValue}}throw new IllegalArgumentException("Unexpected value '" + text + "'");{{/useNullForUnknownEnumValue}}
   }
-
 }

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/formParams.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/formParams.mustache
@@ -1,1 +1,1 @@
-{{#isFormParam}}{{^isFile}}@Multipart(value = "{{baseName}}"{{^required}}, required = false{{/required}})  {{{dataType}}} {{paramName}}{{/isFile}}{{#isFile}} @Multipart(value = "{{baseName}}" {{^required}}, required = false{{/required}}) Attachment {{paramName}}Detail{{/isFile}}{{/isFormParam}}
+{{#isFormParam}}@FormDataParam("{{baseName}}") {{{dataType}}} {{paramName}}{{/isFormParam}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pojo.mustache
@@ -43,7 +43,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensi
   private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
 {{/isContainer}}
   {{/vars}}
-{{#vendorExtensions.x-has-readonly-properties}}{{^withXml}}
+{{#vendorExtensions.x-has-readonly-properties}}{{#jsonb}}
   public {{classname}}() {
   }
 
@@ -57,7 +57,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}}{{#vendorExtensi
     this.{{name}} = {{name}};
   {{/readOnlyVars}}
   }
-  {{/withXml}}{{/vendorExtensions.x-has-readonly-properties}}
+  {{/jsonb}}{{/vendorExtensions.x-has-readonly-properties}}
   {{#vars}}
  /**
   {{#description}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
@@ -38,10 +38,19 @@
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+        </dependency>
 {{#jackson}}
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.2.2</version>
         </dependency>
 {{/jackson}}
 {{#jsonb}}


### PR DESCRIPTION
A few enhancements to the Helidon MP client generator to generate and compile petstore-with-fake-endpoints-models-for-testing.yaml. New script under bin/utils/helidon-test-petstore-e2e.sh for Helidon testing (we may want to skip it from our final push to upstream, but seems useful now). Some other changes related to multipart support.
