### PR TITLE
Use explicit locale to pass forbiddenapis scan

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
@@ -16,6 +16,8 @@
 
 package org.openapitools.codegen.languages;
 
+import java.util.Locale;
+
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.PerformBeanValidationFeatures;
@@ -58,7 +60,8 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
         if (!userHelidonVersion.isEmpty()) {
             if (!userParentVersion.isEmpty() && !userHelidonVersion.equals(userParentVersion)) {
                 throw new IllegalArgumentException(
-                        String.format("Both %s and %s properties were set with different value.",
+                        String.format(Locale.ROOT, 
+                                "Both %s and %s properties were set with different value.",
                                 CodegenConstants.PARENT_VERSION,
                                 HELIDON_VERSION));
             }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonCommonCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonCommonCodegenTest.java
@@ -16,6 +16,15 @@
 
 package org.openapitools.codegen.java.helidon;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.DefaultGenerator;
@@ -23,14 +32,6 @@ import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class JavaHelidonCommonCodegenTest {
 
@@ -97,7 +98,8 @@ public class JavaHelidonCommonCodegenTest {
         List<File> files = generator.generate();
 
         TestUtils.ensureContainsFile(files, Paths.get(outputDir).toFile(), "pom.xml");
-        TestUtils.assertFileContains(Paths.get(outputDir + "/pom.xml"), String.format("<version>%s</version>", expected));
+        TestUtils.assertFileContains(Paths.get(outputDir + "/pom.xml"),
+                String.format(Locale.ROOT, "<version>%s</version>", expected));
     }
 
 }


### PR DESCRIPTION
Use explicit locale to pass forbiddenapis scan.

Signed-off-by: Santiago Pericasgeertsen <santiago.pericasgeertsen@oracle.com>

