### PR TITLE
A few more enhancements to the Helidon MP client generator

### DIFF
--- a/bin/utils/helidon-test-e2e.sh
+++ b/bin/utils/helidon-test-e2e.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# A script to test Helidon generators end-to-end
+#
+
+dir=`pwd`
+executable="${dir}/modules/openapi-generator-cli/target/openapi-generator-cli.jar"
+logfile="/tmp/helidon-test-e2e-output.log"
+project="/tmp/openapi-generator"
+
+# E2E testing for Server MP
+java_helidon_server_mp="
+modules/openapi-generator/src/test/resources/3_0/helidon/petstore-for-testing.yaml
+modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+"
+
+# E2E testing for Server SE
+java_helidon_server_se="
+modules/openapi-generator/src/test/resources/3_0/helidon/petstore-for-testing.yaml
+"
+
+# E2E testing for Client MP
+java_helidon_client_mp="
+modules/openapi-generator/src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml
+modules/openapi-generator/src/test/resources/3_0/helidon/petstore-no-multipart-for-testing.yaml
+"
+
+# E2E testing for Client SE
+java_helidon_client_se="
+modules/openapi-generator/src/test/resources/3_0/helidon/petstore-for-testing.yaml
+"
+
+function help() {
+  echo "$0 (java-helidon-server|java-helidon-client) (mp|se)"
+  exit 1
+}
+
+function verify() {
+  apifiles=`echo "${1}-${2}" | sed 's/-/_/g'`
+
+  for apifile in ${!apifiles}
+  do
+      echo "Generating project for ${apifile} ..."
+
+      ls ${project} >/dev/null 2>&1 && rm -rf ${project}
+
+      if eval java -jar ${executable} generate --input-spec ${apifile} --generator-name ${1} --library ${2} -o ${project} > ${logfile} 2>&1; then
+        echo "Project generated successfully using ${1} ${2}"
+        cp ${apifile} ${project}
+      else
+        echo "ERROR: Failed to run '${1}' generator. The command was:"
+        echo "java -jar ${executable} generate -i ${apifile} -g ${1} -o ${project}"
+        echo "ERROR: The output of the command was:"
+        cat ${logfile}
+        cp ${apifile} ${project}
+        exit 1
+      fi
+
+      echo "Building generated project ..."
+      cd ${project} || exit 1
+      if eval mvn clean package -DskipTests; then
+        echo "Project compiled successfully"
+      else
+        echo "ERROR: Compiling project ${project}"
+        exit 2
+      fi
+      cd ${dir} || exit 1
+
+      echo "========================================================================"
+  done
+
+
+  echo "Generating project from ${apifile} ..."
+  if eval java -jar ${executable} generate -i ${apifile} -g ${1} -o ${project} > ${logfile} 2>&1; then
+    echo "Project generated successfully using ${1}"
+  else
+    echo "ERROR: Failed to run '${1}' generator. The command was:"
+    echo "java -jar ${executable} generate -i ${apifile} -g ${1} -o ${project}"
+    echo "ERROR: The output of the command was:"
+    cat ${logfile}
+    exit 1
+  fi
+
+  echo "Building generated project ..."
+  cd ${project} || exit 1
+  if eval mvn clean install -DskipTests; then
+    echo "Project compiled successfully"
+  else
+    echo "ERROR: Compiling project ${project}"
+    exit 2
+  fi
+
+  echo "Project location is ${project}"
+}
+
+if [ $# -gt 0 ];
+then
+  if [ "$1" == "--help" ];
+  then
+    help
+  fi
+  if [ $# -eq 2 ];
+  then
+    generator="$1"
+    if [ "$generator" != "java-helidon-server" ] && [ "$generator" != "java-helidon-client" ];
+    then
+      help
+    fi
+    library="$2"
+    if [ "$library" != "mp" ] && [ "$library" != "se" ];
+    then
+      help
+   fi
+  verify "$generator" "$library"
+  exit 0
+  fi
+fi
+
+help

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api.mustache
@@ -15,7 +15,6 @@ import {{rootJavaEEPackage}}.ws.rs.*;
 import {{rootJavaEEPackage}}.ws.rs.core.Response;
 import {{rootJavaEEPackage}}.ws.rs.core.MediaType;
 
-import org.glassfish.jersey.media.multipart.*;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
@@ -60,7 +59,7 @@ public interface {{classname}}  {
 {{#hasProduces}}
     @Produces({ {{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}} })
 {{/hasProduces}}
-    {{{returnType}}}{{^returnType}}void{{/returnType}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException, ProcessingException;
+    {{{returnType}}}{{^returnType}}void{{/returnType}} {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>cookieParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException, ProcessingException;
 {{/operation}}
 }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api_test.mustache
@@ -9,7 +9,6 @@ import org.junit.BeforeClass;
 import static org.junit.Assert.*;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.glassfish.jersey.media.multipart.*;
 
 import java.net.URL;
 import java.net.MalformedURLException;
@@ -58,7 +57,6 @@ public class {{classname}}Test {
     public void {{operationId}}Test() throws Exception {
         // TODO: test validations
         {{#allParams}}
-        {{^isFile}}{{{dataType}}} {{paramName}} = null;{{/isFile}}{{#isFile}}MultiPart {{paramName}} = null;{{/isFile}}
         {{/allParams}}
         //{{#returnType}}{{{.}}} response = {{/returnType}}client.{{operationId}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
         //{{#returnType}}assertNotNull(response);{{/returnType}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/bodyParamsImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/bodyParamsImpl.mustache
@@ -1,1 +1,0 @@
-{{#isBodyParam}}{{{dataType}}} {{paramName}}{{/isBodyParam}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/cookieParams.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/cookieParams.mustache
@@ -1,0 +1,1 @@
+{{#isCookieParam}}@CookieParam("{{baseName}}"){{#useBeanValidation}}{{>beanValidationQueryParams}}{{/useBeanValidation}}{{^isContainer}}{{#defaultValue}} @DefaultValue("{{{.}}}"){{/defaultValue}}{{/isContainer}} {{#useSwaggerAnnotations}}{{#description}} @ApiParam("{{.}}"){{/description}}{{/useSwaggerAnnotations}}  {{{dataType}}} {{paramName}}{{/isCookieParam}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/formParams.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/formParams.mustache
@@ -1,1 +1,1 @@
-{{#isFormParam}}@FormDataParam("{{baseName}}") {{{dataType}}} {{paramName}}{{/isFormParam}}
+{{#isFormParam}}@FormParam("{{baseName}}") {{{dataType}}} {{paramName}}{{/isFormParam}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/formParamsImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/formParamsImpl.mustache
@@ -1,1 +1,0 @@
-{{#isFormParam}}{{^isFile}}{{{dataType}}} {{paramName}}{{/isFile}}{{#isFile}} Attachment {{paramName}}Detail{{/isFile}}{{/isFormParam}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/headerParamsImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/headerParamsImpl.mustache
@@ -1,1 +1,0 @@
-{{#isHeaderParam}}{{{dataType}}} {{paramName}}{{/isHeaderParam}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pathParamsImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pathParamsImpl.mustache
@@ -1,1 +1,0 @@
-{{#isPathParam}}{{{dataType}}} {{paramName}}{{/isPathParam}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
@@ -38,10 +38,6 @@
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-multipart</artifactId>
-        </dependency>
 {{#jackson}}
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/queryParamsImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/queryParamsImpl.mustache
@@ -1,1 +1,0 @@
-{{#isQueryParam}}{{{dataType}}} {{paramName}}{{/isQueryParam}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonMpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonMpClientCodegenTest.java
@@ -1,0 +1,97 @@
+package org.openapitools.codegen.java.helidon;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.TestUtils;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.openapitools.codegen.java.assertions.JavaFileAssert.assertThat;
+
+public class JavaHelidonMpClientCodegenTest {
+
+    private String outputPath;
+    private List<File> generatedFiles;
+
+    @BeforeClass
+    public void setup() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+        outputPath = output.getAbsolutePath().replace('\\', '/');
+
+        System.out.println("Generating java-helidon-client MP project in " + outputPath);
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java-helidon-client")
+                .setLibrary("mp")
+                .setInputSpec("src/test/resources/3_0/helidon/petstore-no-multipart-for-testing.yaml")
+                .setOutputDir(outputPath);
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        generator.opts(clientOptInput);
+        generatedFiles = generator.generate();
+    }
+
+    @Test
+    public void testPom() {
+        TestUtils.ensureContainsFile(generatedFiles, new File(outputPath), "pom.xml");
+    }
+
+    @Test
+    public void testPetApi() {
+        assertThat(Paths.get(outputPath + "/src/main/java/org/openapitools/client/api/PetApi.java"))
+                .assertMethod("addPet", "Pet")
+                .toFileAssert()
+                .assertMethod("deletePet", "Long", "String", "Long", "String", "Integer",
+                        "List<Integer>", "List<String>")
+                .toFileAssert()
+                .assertMethod("findPetsByStatus", "List<String>")
+                .toFileAssert()
+                .assertMethod("findPetsByTags", "List<Integer>")
+                .toFileAssert()
+                .assertMethod("getPetById", "Long")
+                .toFileAssert()
+                .assertMethod("updatePet", "Pet")
+                .toFileAssert()
+                .assertMethod("updatePetWithForm", "Long", "String", "String")
+                .toFileAssert();
+    }
+
+    @Test
+    public void testStoreApi() {
+        assertThat(Paths.get(outputPath + "/src/main/java/org/openapitools/client/api/StoreApi.java"))
+                .assertMethod("deleteOrder", "String")
+                .toFileAssert()
+                .assertMethod("getInventory")
+                .toFileAssert()
+                .assertMethod("getOrderById", "BigDecimal")
+                .toFileAssert()
+                .assertMethod("placeOrder", "Order")
+                .toFileAssert();
+    }
+
+    @Test
+    public void testUserApi() {
+        assertThat(Paths.get(outputPath + "/src/main/java/org/openapitools/client/api/UserApi.java"))
+                .assertMethod("createUser", "User")
+                .toFileAssert()
+                .assertMethod("createUsersWithArrayInput", "List<User>")
+                .toFileAssert()
+                .assertMethod("createUsersWithListInput", "List<User>")
+                .toFileAssert()
+                .assertMethod("getUserByName", "String")
+                .toFileAssert()
+                .assertMethod("loginUser", "String", "String", "String", "Long", "BigDecimal")
+                .toFileAssert()
+                .assertMethod("updateUser", "String", "User")
+                .toFileAssert();
+    }
+}

--- a/modules/openapi-generator/src/test/resources/3_0/helidon/petstore-no-multipart-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/helidon/petstore-no-multipart-for-testing.yaml
@@ -1,0 +1,789 @@
+openapi: 3.0.0
+servers:
+  - url: 'http://petstore.helidon.io:8080/v2'
+info:
+  description: >-
+    This spec is mainly for testing Petstore server and contains fake endpoints,
+    models. Please do not use this for any other purpose. For this sample, you can use the api key
+    `special-key` to test the authorization filters. Special characters: "
+    \
+  version: 1.0.0
+  title: OpenAPI Petstore
+  license:
+    name: Apache-2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: pet
+    description: Everything about your Pets
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        $ref: '#/components/requestBodies/Pet'
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        $ref: '#/components/schemas/Pet'
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - 'read:pets'
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: >-
+        Multiple tags can be provided with comma separated strings. Use tag1,
+        tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: integer
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - 'read:pets'
+      deprecated: true
+  '/pet/{petId}':
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - api_key: []
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: headerLong
+          in: header
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: cookieString
+          in: cookie
+          schema:
+            type: string
+          required: true
+        - name: cookieInt
+          in: cookie
+          schema:
+            type: integer
+            format: int32
+          required: false
+        - name: cookieIntArray
+          in: cookie
+          schema:
+            type: array
+            items:
+              type: integer
+          required: false
+        - name: cookieStringArray
+          in: cookie
+          schema:
+            type: array
+            items:
+              type: string
+          required: false
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ''
+      operationId: placeOrder
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+        description: order placed for purchasing the pet
+        required: true
+  '/store/order/{orderId}':
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: >-
+        For valid response try integer IDs with value <= 5 or > 10. Other values
+        will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: number
+            minimum: 1
+            maximum: 5
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: >-
+        For valid response try integer IDs with value < 1000. Anything above
+        1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Created user object
+        required: true
+  /user/createWithArray:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithArrayInput
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithListInput
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+      requestBody:
+        $ref: '#/components/requestBodies/UserArray'
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+            pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+        - name: sizeString
+          in: query
+          description: String param to test Size constraint
+          required: true
+          schema:
+            type: string
+            minLength: 5
+            maxLength: 10
+        - name: minLong
+          in: query
+          description: Min Long param for test
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 10
+        - name: minDecimal
+          in: query
+          description: Min Decimal param for test
+          required: true
+          schema:
+            type: number
+            minimum: 0
+            exclusiveMinimum: true
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            Set-Cookie:
+              description: >-
+                Cookie authentication key for use with the `api_key`
+                apiKey authentication.
+              schema:
+                type: string
+                example: AUTH_KEY=abcde12345; Path=/; HttpOnly
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      responses:
+        default:
+          description: successful operation
+      security:
+        - api_key: []
+  '/user/{username}':
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid user supplied
+        '404':
+          description: User not found
+      security:
+        - api_key: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+      security:
+        - api_key: []
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+components:
+  requestBodies:
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+      description: List of user object
+      required: true
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: 'http://petstore.swagger.io/api/oauth/dialog'
+          scopes:
+            'write:pets': modify pets in your account
+            'read:pets': read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    AnyValue: {}
+    Color:
+      type: string
+      enum:
+        - black
+        - white
+        - red
+        - green
+        - blue
+    Order:
+      title: Pet Order
+      description: An order for a pets from the pet store
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      title: Pet category
+      description: A category for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9]+[a-zA-Z0-9\.\-_]*[a-zA-Z0-9]+$'
+      xml:
+        name: Category
+    User:
+      title: a User
+      description: A User who is purchasing from the pet store
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      title: Pet Tag
+      description: A tag for a pet
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      title: a Pet
+      description: A pet for sale in the pet store
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          $ref: '#/components/schemas/Category'
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      title: An uploaded response
+      description: Describes the result of uploading an image resource
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+    PetsForm:
+      type: object
+      properties:
+        images[]:
+          type: array
+          items:
+            type: string
+            format: binary
+        image:
+          type: string
+          format: binary
+        titles[]:
+          type: array
+          items:
+            type: string
+        longArray:
+          type: array
+          items:
+            type: integer
+            format: int64
+        stringParam:
+          type: string
+        intParam:
+          type: integer
+          format: int32
+      required:
+        - stringParam


### PR DESCRIPTION
A few more enhancements to the Helidon MP client generator:

 - Removal of multipart support since it is not supported in RestClient
 - Fixed problems with @CookieParams
 - New unit test for the Client MP generator
 - Removal of some unused templates
 - Support for helidonVersion/parentVersion after rebase
 - New helidon-test-e2e.sh script for e2e testing with a list of files to test per helidon flavor

The new helidon-test-e2e.sh should be useful to others as well.

