### PR TITLE
Some cleanup of properties in docs, pom template and generator

### DIFF
--- a/docs/generators/java-helidon-client.md
+++ b/docs/generators/java-helidon-client.md
@@ -30,11 +30,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |booleanGetterPrefix|Set booleanGetterPrefix| |get|
 |configKey|Config key in @RegisterRestClient. Default to none.| |null|
 |dateLibrary|Option. Date library to use|<dl><dt>**joda**</dt><dd>Joda (for legacy app only)</dd><dt>**legacy**</dt><dd>Legacy java.util.Date</dd><dt>**java8-localdatetime**</dt><dd>Java 8 using LocalDateTime (for legacy app only)</dd><dt>**java8**</dt><dd>Java 8 native JSR310 (preferred for jdk 1.8+)</dd></dl>|java8|
-|developerEmail|developer email in generated pom.xml| |team@openapitools.org|
-|developerName|developer name in generated pom.xml| |OpenAPI-Generator Contributors|
-|developerOrganization|developer organization in generated pom.xml| |OpenAPITools.org|
-|developerOrganizationUrl|developer organization URL in generated pom.xml| |http://openapitools.org|
-|disableHtmlEscaping|Disable HTML escaping of JSON strings when using gson (needed to avoid problems with byte[] fields)| |false|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |discriminatorCaseSensitive|Whether the discriminator value lookup should be case-sensitive or not. This option only works for Java API client| |true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|
@@ -53,13 +48,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |licenseUrl|The URL of the license| |http://unlicense.org|
 |modelPackage|package for generated models| |org.openapitools.client.model|
 |openApiNullable|Enable OpenAPI Jackson Nullable library| |true|
-|parentArtifactId|parent artifactId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
-|parentGroupId|parent groupId in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
-|parentVersion|parent version in generated pom N.B. parentGroupId, parentArtifactId and parentVersion must all be specified for any of them to take effect| |null|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
-|scmConnection|SCM connection in generated pom.xml| |scm:git:git@github.com:openapitools/openapi-generator.git|
-|scmDeveloperConnection|SCM developer connection in generated pom.xml| |scm:git:git@github.com:openapitools/openapi-generator.git|
-|scmUrl|SCM URL in generated pom.xml| |https://github.com/openapitools/openapi-generator|
+|rootJavaEEPackage|root package name for Java EE|**javax** or **jakarta**|javax|
 |serializableModel|boolean - toggle &quot;implements Serializable&quot; for generated models| |false|
 |serializationLibrary|Serialization library, defaults to Jackson|<dl><dt>**jsonb**</dt><dd>Use JSON-B as serialization library</dd><dt>**jackson**</dt><dd>Use Jackson as serialization library</dd></dl>|null|
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd></dl>|null|
@@ -83,7 +73,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |x-field-extra-annotation|List of custom annotations to be added to property|FIELD|null
 |x-webclient-blocking|Specifies if method for specific operation should be blocking or non-blocking(ex: return `Mono<T>/Flux<T>` or `return T/List<T>/Set<T>` & execute `.block()` inside generated method)|OPERATION|false
 
-
 ## IMPORT MAPPING
 
 | Type/Alias | Imports |
@@ -106,7 +95,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |URI|java.net.URI|
 |UUID|java.util.UUID|
 
-
 ## INSTANTIATION TYPES
 
 | Type/Alias | Instantiated By |
@@ -114,7 +102,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |array|ArrayList|
 |map|HashMap|
 |set|LinkedHashSet|
-
 
 ## LANGUAGE PRIMITIVES
 
@@ -206,9 +193,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>volatile</li>
 <li>while</li>
 </ul>
-
-## FEATURE SET
-
 
 ### Client Modification Feature
 | Name | Supported | Defined By |

--- a/docs/generators/java-helidon-client.md
+++ b/docs/generators/java-helidon-client.md
@@ -49,6 +49,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |modelPackage|package for generated models| |org.openapitools.client.model|
 |openApiNullable|Enable OpenAPI Jackson Nullable library| |true|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
+|rootJavaEEPackage|Root package name for Java EE| |javax|
 |serializableModel|boolean - toggle &quot;implements Serializable&quot; for generated models| |false|
 |serializationLibrary|Serialization library, defaults to Jackson|<dl><dt>**jsonb**</dt><dd>Use JSON-B as serialization library</dd><dt>**jackson**</dt><dd>Use Jackson as serialization library</dd></dl>|null|
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd></dl>|null|

--- a/docs/generators/java-helidon-client.md
+++ b/docs/generators/java-helidon-client.md
@@ -49,7 +49,6 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |modelPackage|package for generated models| |org.openapitools.client.model|
 |openApiNullable|Enable OpenAPI Jackson Nullable library| |true|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
-|rootJavaEEPackage|root package name for Java EE|**javax** or **jakarta**|javax|
 |serializableModel|boolean - toggle &quot;implements Serializable&quot; for generated models| |false|
 |serializationLibrary|Serialization library, defaults to Jackson|<dl><dt>**jsonb**</dt><dd>Use JSON-B as serialization library</dd><dt>**jackson**</dt><dd>Use Jackson as serialization library</dd></dl>|null|
 |snapshotVersion|Uses a SNAPSHOT version.|<dl><dt>**true**</dt><dd>Use a SnapShot Version</dd><dt>**false**</dt><dd>Use a Release Version</dd></dl>|null|
@@ -73,6 +72,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |x-field-extra-annotation|List of custom annotations to be added to property|FIELD|null
 |x-webclient-blocking|Specifies if method for specific operation should be blocking or non-blocking(ex: return `Mono<T>/Flux<T>` or `return T/List<T>/Set<T>` & execute `.block()` inside generated method)|OPERATION|false
 
+
 ## IMPORT MAPPING
 
 | Type/Alias | Imports |
@@ -95,6 +95,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |URI|java.net.URI|
 |UUID|java.util.UUID|
 
+
 ## INSTANTIATION TYPES
 
 | Type/Alias | Instantiated By |
@@ -102,6 +103,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |array|ArrayList|
 |map|HashMap|
 |set|LinkedHashSet|
+
 
 ## LANGUAGE PRIMITIVES
 
@@ -193,6 +195,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>volatile</li>
 <li>while</li>
 </ul>
+
+## FEATURE SET
+
 
 ### Client Modification Feature
 | Name | Supported | Defined By |

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
@@ -46,6 +48,16 @@ import org.openapitools.codegen.model.OperationsMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.openapitools.codegen.CodegenConstants.DEVELOPER_EMAIL;
+import static org.openapitools.codegen.CodegenConstants.DEVELOPER_NAME;
+import static org.openapitools.codegen.CodegenConstants.DEVELOPER_ORGANIZATION;
+import static org.openapitools.codegen.CodegenConstants.DEVELOPER_ORGANIZATION_URL;
+import static org.openapitools.codegen.CodegenConstants.PARENT_ARTIFACT_ID;
+import static org.openapitools.codegen.CodegenConstants.PARENT_GROUP_ID;
+import static org.openapitools.codegen.CodegenConstants.PARENT_VERSION;
+import static org.openapitools.codegen.CodegenConstants.SCM_CONNECTION;
+import static org.openapitools.codegen.CodegenConstants.SCM_DEVELOPER_CONNECTION;
+import static org.openapitools.codegen.CodegenConstants.SCM_URL;
 import static org.openapitools.codegen.CodegenConstants.SERIALIZATION_LIBRARY;
 
 public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
@@ -116,6 +128,19 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
         serializationLibrary.setEnum(serializationOptions);
         cliOptions.add(serializationLibrary);
         setSerializationLibrary(SERIALIZATION_LIBRARY_JACKSON);     // default
+
+        // Remove currently unsupported options from base classes
+        removeCliOptions(SCM_CONNECTION,
+                SCM_DEVELOPER_CONNECTION,
+                SCM_URL,
+                DEVELOPER_NAME,
+                DEVELOPER_ORGANIZATION,
+                DEVELOPER_ORGANIZATION_URL,
+                DEVELOPER_EMAIL,
+                PARENT_ARTIFACT_ID,
+                PARENT_VERSION,
+                PARENT_GROUP_ID,
+                DISABLE_HTML_ESCAPING);
 
         // Ensure the OAS 3.x discriminator mappings include any descendent schemas that allOf
         // inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values,
@@ -405,5 +430,12 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
         List<VendorExtension> extensions = super.getSupportedVendorExtensions();
         extensions.add(VendorExtension.X_WEBCLIENT_BLOCKING);
         return extensions;
+    }
+    private void removeCliOptions(String... opt) {
+        List<String> opts = Arrays.asList(opt);
+        Set<CliOption> forRemoval = cliOptions.stream()
+                .filter(cliOption -> opts.contains(cliOption.getOpt()))
+                .collect(Collectors.toSet());
+        forRemoval.forEach(cliOptions::remove);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
@@ -46,16 +46,6 @@ import org.openapitools.codegen.model.OperationsMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.openapitools.codegen.CodegenConstants.DEVELOPER_EMAIL;
-import static org.openapitools.codegen.CodegenConstants.DEVELOPER_NAME;
-import static org.openapitools.codegen.CodegenConstants.DEVELOPER_ORGANIZATION;
-import static org.openapitools.codegen.CodegenConstants.DEVELOPER_ORGANIZATION_URL;
-import static org.openapitools.codegen.CodegenConstants.PARENT_ARTIFACT_ID;
-import static org.openapitools.codegen.CodegenConstants.PARENT_GROUP_ID;
-import static org.openapitools.codegen.CodegenConstants.PARENT_VERSION;
-import static org.openapitools.codegen.CodegenConstants.SCM_CONNECTION;
-import static org.openapitools.codegen.CodegenConstants.SCM_DEVELOPER_CONNECTION;
-import static org.openapitools.codegen.CodegenConstants.SCM_URL;
 import static org.openapitools.codegen.CodegenConstants.SERIALIZATION_LIBRARY;
 
 public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
@@ -127,18 +117,7 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
         cliOptions.add(serializationLibrary);
         setSerializationLibrary(SERIALIZATION_LIBRARY_JACKSON);     // default
 
-        // Remove currently unsupported options from base classes
-        removeCliOptions(SCM_CONNECTION,
-                SCM_DEVELOPER_CONNECTION,
-                SCM_URL,
-                DEVELOPER_NAME,
-                DEVELOPER_ORGANIZATION,
-                DEVELOPER_ORGANIZATION_URL,
-                DEVELOPER_EMAIL,
-                PARENT_ARTIFACT_ID,
-                PARENT_VERSION,
-                PARENT_GROUP_ID,
-                DISABLE_HTML_ESCAPING);
+        removeUnusedOptions();
 
         // Ensure the OAS 3.x discriminator mappings include any descendent schemas that allOf
         // inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values,

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
@@ -23,8 +23,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
@@ -99,7 +97,7 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
         artifactId = "openapi-java-client";
         apiPackage = invokerPackage + ".api";
         modelPackage = invokerPackage + ".model";
-        rootJavaEEPackage = MICROPROFILE_REST_CLIENT_DEFAULT_ROOT_PACKAGE;
+        rootJavaEEPackage = MICROPROFILE_ROOT_PACKAGE_DEFAULT;
 
         updateOption(CodegenConstants.INVOKER_PACKAGE, getInvokerPackage());
         updateOption(CodegenConstants.ARTIFACT_ID, getArtifactId());
@@ -176,8 +174,8 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
     public void processOpts() {
         super.processOpts();
 
-        if (!additionalProperties.containsKey(MICROPROFILE_ROOT_PACKAGE_PROPERTY)) {
-            additionalProperties.put(MICROPROFILE_ROOT_PACKAGE_PROPERTY, rootJavaEEPackage);
+        if (!additionalProperties.containsKey(MICROPROFILE_ROOT_PACKAGE)) {
+            additionalProperties.put(MICROPROFILE_ROOT_PACKAGE, rootJavaEEPackage);
         }
 
         if (additionalProperties.containsKey(SERIALIZATION_LIBRARY)) {
@@ -430,12 +428,5 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
         List<VendorExtension> extensions = super.getSupportedVendorExtensions();
         extensions.add(VendorExtension.X_WEBCLIENT_BLOCKING);
         return extensions;
-    }
-    private void removeCliOptions(String... opt) {
-        List<String> opts = Arrays.asList(opt);
-        Set<CliOption> forRemoval = cliOptions.stream()
-                .filter(cliOption -> opts.contains(cliOption.getOpt()))
-                .collect(Collectors.toSet());
-        forRemoval.forEach(cliOptions::remove);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonClientCodegen.java
@@ -19,6 +19,8 @@
 package org.openapitools.codegen.languages;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -165,27 +167,30 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
             setConfigKey(additionalProperties.get(CONFIG_KEY).toString());
         }
 
-        String invokerFolder = (sourceFolder + '/' + invokerPackage).replace(".", "/");
-        authFolder = (sourceFolder + '/' + invokerPackage + ".auth").replace(".", "/");
+        String invokerPath = invokerPackage.replace('.', File.separatorChar);
+        Path invokerFolder = Paths.get(sourceFolder, invokerPath);
+        authFolder = invokerFolder.resolve("auth").toString();
 
         if (isLibrary(HELIDON_MP)) {
-            String apiExceptionFolder = (sourceFolder + File.separator
-                    + apiPackage().replace('.', File.separatorChar)).replace('/', File.separatorChar);
+            String apiExceptionFolder = Paths.get(sourceFolder,
+                    apiPackage().replace('.', File.separatorChar)).toString();
+
             supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
             supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
             supportingFiles.add(new SupportingFile("api_exception.mustache", apiExceptionFolder, "ApiException.java"));
             supportingFiles.add(new SupportingFile("api_exception_mapper.mustache", apiExceptionFolder, "ApiExceptionMapper.java"));
 
             if (additionalProperties.containsKey("jsr310")) {
-                supportingFiles.add(new SupportingFile("JavaTimeFormatter.mustache", invokerFolder, "JavaTimeFormatter.java"));
+                supportingFiles.add(new SupportingFile("JavaTimeFormatter.mustache",
+                        invokerFolder.toString(), "JavaTimeFormatter.java"));
             }
         } else if (isLibrary(HELIDON_SE)) {
             // TODO check for SE-specifics and supporting files used for both MP and SE
             supportingFiles.clear();
             supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml"));
             supportingFiles.add(new SupportingFile("README.mustache", "", "README.md"));
-            supportingFiles.add(new SupportingFile("ApiClient.mustache", invokerFolder, "ApiClient.java"));
-            supportingFiles.add(new SupportingFile("Pair.mustache", invokerFolder, "Pair.java"));
+            supportingFiles.add(new SupportingFile("ApiClient.mustache", invokerFolder.toString(), "ApiClient.java"));
+            supportingFiles.add(new SupportingFile("Pair.mustache", invokerFolder.toString(), "Pair.java"));
         }
         else {
             LOGGER.error("Unknown library option (-l/--library): {}", getLibrary());
@@ -199,7 +204,7 @@ public class JavaHelidonClientCodegen extends JavaHelidonCommonCodegen {
             case SERIALIZATION_LIBRARY_JACKSON:
                 additionalProperties.put(SERIALIZATION_LIBRARY_JACKSON, "true");
                 additionalProperties.remove(SERIALIZATION_LIBRARY_JSONB);
-                supportingFiles.add(new SupportingFile("RFC3339DateFormat.mustache", invokerFolder, "RFC3339DateFormat.java"));
+                supportingFiles.add(new SupportingFile("RFC3339DateFormat.mustache", invokerFolder.toString(), "RFC3339DateFormat.java"));
                 break;
             case SERIALIZATION_LIBRARY_JSONB:
                 openApiNullable = false;        // for Jackson only

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
@@ -16,7 +16,11 @@
 
 package org.openapitools.codegen.languages;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
@@ -29,11 +33,12 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
     static final String HELIDON_MP = "mp";
     static final String HELIDON_SE = "se";
 
-    static final String MICROPROFILE_REST_CLIENT_DEFAULT_ROOT_PACKAGE = "javax";
     static final String HELIDON_NIMA = "nima";
     static final String HELIDON_NIMA_ANNOTATIONS = "nima-annotations";
 
-    static final String MICROPROFILE_ROOT_PACKAGE_PROPERTY = "rootJavaEEPackage";
+    static final String MICROPROFILE_ROOT_PACKAGE = "rootJavaEEPackage";
+    static final String MICROPROFILE_ROOT_PACKAGE_DESC = "Root package name for Java EE";
+    static final String MICROPROFILE_ROOT_PACKAGE_DEFAULT = "javax";
 
     static final String SERIALIZATION_LIBRARY_JACKSON = "jackson";
     static final String SERIALIZATION_LIBRARY_JSONB = "jsonb";
@@ -46,7 +51,10 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
 
     public JavaHelidonCommonCodegen() {
         super();
-        cliOptions.add(new CliOption(HELIDON_VERSION, HELIDON_VERSION_DESC).defaultValue(DEFAULT_HELIDON_VERSION));
+        cliOptions.add(new CliOption(HELIDON_VERSION, HELIDON_VERSION_DESC)
+                .defaultValue(DEFAULT_HELIDON_VERSION));
+        cliOptions.add(new CliOption(MICROPROFILE_ROOT_PACKAGE, MICROPROFILE_ROOT_PACKAGE_DESC)
+                .defaultValue(MICROPROFILE_ROOT_PACKAGE_DEFAULT));
     }
 
     @Override
@@ -85,5 +93,13 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
     private void setHelidonVersion(String version) {
         helidonVersion = version;
         setParentVersion(version);
+    }
+
+    protected void removeCliOptions(String... opt) {
+        List<String> opts = Arrays.asList(opt);
+        Set<CliOption> forRemoval = cliOptions.stream()
+                .filter(cliOption -> opts.contains(cliOption.getOpt()))
+                .collect(Collectors.toSet());
+        forRemoval.forEach(cliOptions::remove);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonCommonCodegen.java
@@ -27,6 +27,17 @@ import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.languages.features.BeanValidationFeatures;
 import org.openapitools.codegen.languages.features.PerformBeanValidationFeatures;
 
+import static org.openapitools.codegen.CodegenConstants.DEVELOPER_EMAIL;
+import static org.openapitools.codegen.CodegenConstants.DEVELOPER_NAME;
+import static org.openapitools.codegen.CodegenConstants.DEVELOPER_ORGANIZATION;
+import static org.openapitools.codegen.CodegenConstants.DEVELOPER_ORGANIZATION_URL;
+import static org.openapitools.codegen.CodegenConstants.PARENT_ARTIFACT_ID;
+import static org.openapitools.codegen.CodegenConstants.PARENT_GROUP_ID;
+import static org.openapitools.codegen.CodegenConstants.PARENT_VERSION;
+import static org.openapitools.codegen.CodegenConstants.SCM_CONNECTION;
+import static org.openapitools.codegen.CodegenConstants.SCM_DEVELOPER_CONNECTION;
+import static org.openapitools.codegen.CodegenConstants.SCM_URL;
+
 public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
         implements BeanValidationFeatures, PerformBeanValidationFeatures {
 
@@ -88,6 +99,24 @@ public abstract class JavaHelidonCommonCodegen extends AbstractJavaCodegen
         }
 
         additionalProperties.put(HELIDON_VERSION, helidonVersion);
+    }
+
+    /**
+     * Remove set of options not currently used by any Helidon generator. Should be
+     * called during construction but only on leaf classes.
+     */
+    protected void removeUnusedOptions() {
+        removeCliOptions(SCM_CONNECTION,
+                SCM_DEVELOPER_CONNECTION,
+                SCM_URL,
+                DEVELOPER_NAME,
+                DEVELOPER_ORGANIZATION,
+                DEVELOPER_ORGANIZATION_URL,
+                DEVELOPER_EMAIL,
+                PARENT_ARTIFACT_ID,
+                PARENT_VERSION,
+                PARENT_GROUP_ID,
+                DISABLE_HTML_ESCAPING);
     }
 
     private void setHelidonVersion(String version) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
@@ -112,6 +112,8 @@ public class JavaHelidonServerCodegen extends JavaHelidonCommonCodegen {
         cliOptions.add(serializationLibrary);
         setSerializationLibrary(SERIALIZATION_LIBRARY_JACKSON);
 
+        removeUnusedOptions();
+
         this.setLegacyDiscriminatorBehavior(false);
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
@@ -154,8 +154,8 @@ public class JavaHelidonServerCodegen extends JavaHelidonCommonCodegen {
             additionalProperties.remove(FULL_PROJECT);
         }
 
-        if (!additionalProperties.containsKey(MICROPROFILE_ROOT_PACKAGE_PROPERTY)) {
-            additionalProperties.put(MICROPROFILE_ROOT_PACKAGE_PROPERTY, MICROPROFILE_REST_CLIENT_DEFAULT_ROOT_PACKAGE);
+        if (!additionalProperties.containsKey(MICROPROFILE_ROOT_PACKAGE)) {
+            additionalProperties.put(MICROPROFILE_ROOT_PACKAGE, MICROPROFILE_ROOT_PACKAGE_DEFAULT);
         }
 
         if (additionalProperties.containsKey(CodegenConstants.SERIALIZATION_LIBRARY)) {

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
@@ -11,10 +11,9 @@
     </parent>
     <artifactId>{{artifactId}}</artifactId>
     <name>{{artifactId}}</name>
-    {{#appDescription}}
-        <description>{{.}}</description>
-    {{/appDescription}}
     <version>{{artifactVersion}}</version>
+    <url>{{artifactUrl}}</url>
+    <description>{{artifactDescription}}</description>
     <packaging>jar</packaging>
 
     <dependencies>


### PR DESCRIPTION
Some cleanup of properties in docs, pom template and generator. Removed properties that are currently not supported or do not apply to Helidon. Also uses `Path`s for folders.
