### PR TITLE
Fix junit dependency

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
@@ -156,8 +156,8 @@ public class JavaHelidonServerCodegen extends JavaHelidonCommonCodegen {
         writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
 
         importMapping.put("ObjectMapper", "com.fasterxml.jackson.databind.ObjectMapper");
-        importMapping.put("Jsonb", "javax.json.bind.Jsonb");
-        importMapping.put("JsonbBuilder", "javax.json.bind.JsonbBuilder");
+        importMapping.put("Jsonb", rootJavaEEPackage() + ".json.bind.Jsonb");
+        importMapping.put("JsonbBuilder", rootJavaEEPackage() + ".json.bind.JsonbBuilder");
 
         if (additionalProperties.containsKey(USE_ABSTRACT_CLASS)) {
             useAbstractClass = Boolean.parseBoolean(additionalProperties.get(USE_ABSTRACT_CLASS).toString());

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/api_test.mustache
@@ -4,9 +4,9 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-import org.junit.Test;
-import org.junit.BeforeClass;
-import static org.junit.Assert.*;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
@@ -32,7 +32,7 @@ public class {{classname}}Test {
     private static {{classname}} client;
     private static final String baseUrl = "http://localhost:8080";
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws MalformedURLException {
         client = RestClientBuilder.newBuilder()
                         .baseUrl(new URL(baseUrl))

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/model_test.mustache
@@ -4,9 +4,8 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 {{#fullJavaUtil}}
 import java.util.ArrayList;

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
@@ -59,8 +59,8 @@
         </dependency>
 {{/jsonb}}
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/mp/pom.mustache
@@ -30,12 +30,12 @@
             <artifactId>jersey-cdi1x</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <groupId>{{x-helidon-rootJavaEEDepPrefix}}.enterprise</groupId>
+            <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
+            <groupId>{{x-helidon-rootJavaEEDepPrefix}}.json</groupId>
+            <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.json-api</artifactId>
         </dependency>
 {{#jackson}}
         <dependency>
@@ -54,8 +54,8 @@
             <artifactId>jersey-media-json-binding</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
+            <groupId>{{x-helidon-rootJavaEEDepPrefix}}.json.bind</groupId>
+            <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.json.bind-api</artifactId>
         </dependency>
 {{/jsonb}}
         <dependency>

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/ApiClient.mustache
@@ -1,8 +1,8 @@
 {{>licenseInfo}}
 package {{invokerPackage}};
 
-{{#jsonb}}import javax.json.bind.JsonbBuilder;
-import javax.json.bind.JsonbConfig;
+{{#jsonb}}import {{rootJavaEEPackage}}.json.bind.JsonbBuilder;
+import {{rootJavaEEPackage}}.json.bind.JsonbConfig;
 {{/jsonb}}
 {{#jackson}}import com.fasterxml.jackson.databind.ObjectMapper;
 {{/jackson}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/api_test.mustache
@@ -8,8 +8,8 @@ package {{package}};
 import {{invokerPackage}}.ApiClient;
 import {{invokerPackage}}.ApiResponse;
 
-import org.junit.Test;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 {{^fullJavaUtil}}
 import java.util.ArrayList;
@@ -37,7 +37,7 @@ public class {{classname}}Test {
     private static {{classname}} api;
     private static final String baseUrl = "http://localhost:8080";
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         apiClient = ApiClient.builder().build();
         api = {{classname}}Impl.create(apiClient);

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/model_test.mustache
@@ -4,9 +4,8 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 {{#fullJavaUtil}}
 import java.util.ArrayList;

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
@@ -27,8 +27,8 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json</groupId>
-            <artifactId>jakarta.json-api</artifactId>
+            <groupId>{{x-helidon-rootJavaEEDepPrefix}}.json</groupId>
+            <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.json-api</artifactId>
         </dependency>
 {{#jackson}}
         <dependency>
@@ -51,8 +51,8 @@
             <artifactId>jersey-media-json-binding</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
+            <groupId>{{x-helidon-rootJavaEEDepPrefix}}.json.bind</groupId>
+            <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.json.bind-api</artifactId>
         </dependency>
 {{/jsonb}}
         <dependency>

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/pom.mustache
@@ -56,8 +56,8 @@
         </dependency>
 {{/jsonb}}
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/api.mustache
@@ -15,8 +15,8 @@ import java.util.concurrent.CompletableFuture;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.List;
-{{#useBeanValidation}}import javax.validation.constraints.*;
-import javax.validation.Valid;{{/useBeanValidation}}
+{{#useBeanValidation}}import {{rootJavaEEPackage}}.validation.constraints.*;
+import {{rootJavaEEPackage}}.validation.Valid;{{/useBeanValidation}}
 
 @Path("{{commonPath}}"){{#hasConsumes}}
 @Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/apiImpl.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/apiImpl.mustache
@@ -15,8 +15,8 @@ import java.util.concurrent.CompletableFuture;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.List;
-{{#useBeanValidation}}import javax.validation.constraints.*;
-import javax.validation.Valid;{{/useBeanValidation}}
+{{#useBeanValidation}}import {{rootJavaEEPackage}}.validation.constraints.*;
+import {{rootJavaEEPackage}}.validation.Valid;{{/useBeanValidation}}
 
 @Path("{{commonPath}}"){{#hasConsumes}}
 @Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/api_test.mustache
@@ -4,7 +4,7 @@ package {{package}};
 
 {{#imports}}import {{import}};
 {{/imports}}
-import javax.inject.Inject;
+import {{rootJavaEEPackage}}.inject.Inject;
 import {{rootJavaEEPackage}}.ws.rs.client.WebTarget;
 
 import org.junit.jupiter.api.Test;

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/build.gradle.mustache
@@ -37,14 +37,14 @@ dependencies {
     implementation enforcedPlatform("io.helidon:helidon-dependencies:${project.helidonVersion}")
     implementation 'io.helidon.microprofile.bundles:helidon-microprofile-core'
     implementation 'io.helidon.microprofile.cdi:helidon-microprofile-cdi'
-    implementation 'jakarta.enterprise:jakarta.enterprise.cdi-api'
-    implementation 'jakarta.ws.rs:jakarta.ws.rs-api'
+    implementation '{{rootJavaEEPackage}}.enterprise:{{rootJavaEEPackage}}.enterprise.cdi-api'
+    implementation '{{rootJavaEEPackage}}.ws.rs:{{rootJavaEEPackage}}.ws.rs-api'
 {{#jackson}}
     implementation 'org.glassfish.jersey.media:jersey-media-json-jackson'
 {{/jackson}}
 {{#jsonb}}
     implementation 'org.glassfish.jersey.media:jersey-media-json-binding'
-    implementation 'jakarta.json.bind:jakarta.json.bind-api'
+    implementation '{{rootJavaEEPackage}}.json.bind:{{rootJavaEEPackage}}.json.bind-api'
 {{/jsonb}}
     testImplementation 'junit:junit'
     testImplementation 'io.helidon.microprofile.tests:helidon-microprofile-tests-junit5'

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})
+@{{rootJavaEEPackage}}.annotation.Generated(value = "{{generatorClass}}"{{^hideGenerationTimestamp}}, date = "{{generatedDate}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/pom.mustache
@@ -17,9 +17,11 @@
     <version>{{artifactVersion}}</version>
     <packaging>jar</packaging>
 
+{{#openApiNullable}}
     <properties>
         <version.jackson.databind.nullable>0.2.3</version.jackson.databind.nullable>
     </properties>
+{{/openApiNullable}}
 
     <dependencies>
         <dependency>
@@ -31,12 +33,12 @@
             <artifactId>helidon-microprofile-cdi</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <groupId>{{x-helidon-rootJavaEEDepPrefix}}.enterprise</groupId>
+            <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
+            <groupId>{{x-helidon-rootJavaEEDepPrefix}}.ws.rs</groupId>
+            <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.ws.rs-api</artifactId>
         </dependency>
 {{#openApiNullable}}
         <dependency>
@@ -57,8 +59,8 @@
             <artifactId>jersey-media-json-binding</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.json.bind</groupId>
-            <artifactId>jakarta.json.bind-api</artifactId>
+            <groupId>{{x-helidon-rootJavaEEDepPrefix}}.json.bind</groupId>
+            <artifactId>{{x-helidon-rootJavaEEDepPrefix}}.json.bind-api</artifactId>
         </dependency>
 {{/jsonb}}
         <dependency>

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/build.gradle.mustache
@@ -38,7 +38,7 @@ repositories {
 dependencies {
     // import Helidon BOM
     implementation enforcedPlatform("io.helidon:helidon-dependencies:${project.helidonVersion}")
-    implementation "javax.validation:validation-api:${project.validationApiVersion}"
+    implementation "{{x-helidon-validationArtifactPrefix}}.validation:{{x-helidon-validationArtifactPrefix}}validation-api:${project.validationApiVersion}"
     implementation 'io.helidon.webserver:helidon-webserver'
     implementation 'io.helidon.media:helidon-media-jsonp'
 {{#jackson}}

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/generatedAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/generatedAnnotation.mustache
@@ -1,1 +1,1 @@
-@javax.annotation.Generated(value = "{{{generatorClass}}}"{{^hideGenerationTimestamp}}, date = "{{{generatedDate}}}"{{/hideGenerationTimestamp}})
+@{{rootJavaEEPackage}}.annotation.Generated(value = "{{{generatorClass}}}"{{^hideGenerationTimestamp}}, date = "{{{generatedDate}}}"{{/hideGenerationTimestamp}})

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/mainTest.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/mainTest.mustache
@@ -3,8 +3,8 @@ package {{invokerPackage}};
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import javax.json.Json;
-import javax.json.JsonBuilderFactory;
+import {{rootJavaEEPackage}}.json.Json;
+import {{rootJavaEEPackage}}.json.JsonBuilderFactory;
 
 import io.helidon.media.jsonp.JsonpSupport;
 import io.helidon.webclient.WebClient;

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/pom.mustache
@@ -19,15 +19,13 @@
 
     <properties>
         <mainClass>{{{invokerPackage}}}.Main</mainClass>
-        <version.validation.api>2.0.1.Final</version.validation.api>
         <version.jackson.databind.nullable>0.2.3</version.jackson.databind.nullable>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>${version.validation.api}</version>
+            <groupId>{{x-helidon-rootJavaEEDepPrefix}}.validation</groupId>
+            <artifactId>{{x-helidon-validationArtifactPrefix}}validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/validatorUtils.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/validatorUtils.mustache
@@ -6,7 +6,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 
-import javax.validation.ValidationException;
+import {{rootJavaEEPackage}}.validation.ValidationException;
 
 /**
 * Validation utility methods.

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonMpServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/JavaHelidonMpServerCodegenTest.java
@@ -78,7 +78,7 @@ public class JavaHelidonMpServerCodegenTest {
         generate(createConfigurator().addAdditionalProperty(SERIALIZATION_LIBRARY, "jsonb"));
 
         JavaFileAssert.assertThat(Paths.get(modelPackage + "/Color.java"))
-                .fileContains("javax.json.bind.annotation.JsonbCreator");
+                .fileContains(".json.bind.annotation.JsonbCreator");
     }
 
     @Test


### PR DESCRIPTION
Resolves helidon-io/helidon#4914 

The client generators were based on Junit 4. This PR updates them to JUnit 5 (pom dependency and imports) which Helidon's parent application pom manages. See the `*_test.mustache` templates in the change list.

Addressing this also unveiled numerous issues with javax vs jakarta imports and dependencies, which this PR also addresses.

* For `javax` vs `jakarta`, we must separately deal with `import`s and dependencies. Plus, one dependency, validation, changed its artifact name structure (the `javax` version did not have `javax` prefix in the artifact name; the `jakarta` artifact name includes `jakarta` as a prefix).
* The functional tests now infer what Helidon version they should use based on the currently-set Java version. Earlier changes Thibault made in the GitHub action workflow runs the functional tests twice, once under Java 11 and once under 13, so we have better coverage of the `javax` vs. `jakarta` handling by running both ways.
