### PR TITLE
fix issues related to Json provider in Helidon SE server generator and java version issue in FunctionalTest

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaHelidonServerCodegen.java
@@ -156,8 +156,10 @@ public class JavaHelidonServerCodegen extends JavaHelidonCommonCodegen {
         writePropertyBack(USE_BEANVALIDATION, useBeanValidation);
 
         importMapping.put("ObjectMapper", "com.fasterxml.jackson.databind.ObjectMapper");
-        importMapping.put("Jsonb", "javax.json.bind.Jsonb");
-        importMapping.put("JsonbBuilder", "javax.json.bind.JsonbBuilder");
+        importMapping.put("Jsonb",
+                String.format(Locale.ROOT, "%s.json.bind.Jsonb", additionalProperties.get(MICROPROFILE_ROOT_PACKAGE)));
+        importMapping.put("JsonbBuilder",
+                String.format(Locale.ROOT, "%s.json.bind.JsonbBuilder", additionalProperties.get(MICROPROFILE_ROOT_PACKAGE)));
 
         if (additionalProperties.containsKey(USE_ABSTRACT_CLASS)) {
             useAbstractClass = Boolean.parseBoolean(additionalProperties.get(USE_ABSTRACT_CLASS).toString());

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/mainTest.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/se/mainTest.mustache
@@ -3,8 +3,8 @@ package {{invokerPackage}};
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import javax.json.Json;
-import javax.json.JsonBuilderFactory;
+import {{rootJavaEEPackage}}.json.Json;
+import {{rootJavaEEPackage}}.json.JsonBuilderFactory;
 
 import io.helidon.media.jsonp.JsonpSupport;
 import io.helidon.webclient.WebClient;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/functional/FunctionalBase.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/functional/FunctionalBase.java
@@ -149,7 +149,12 @@ abstract class FunctionalBase {
 
     protected int getCurrentJavaMajorVersion() {
         String[] versionElements = System.getProperty("java.version").split("\\.");
-        return Integer.parseInt(versionElements[0]);
+        int firstElement = Integer.parseInt(versionElements[0]);
+        if (firstElement == 1) {
+            return Integer.parseInt(versionElements[1]);
+        } else {
+            return firstElement;
+        }
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/functional/FunctionalBase.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/functional/FunctionalBase.java
@@ -59,6 +59,8 @@ abstract class FunctionalBase {
 
     protected static final String FULL_PROJECT = "fullProject";
     protected static final String USE_ABSTRACT_CLASS = "useAbstractClass";
+    protected static final String HELIDON_VERSION = "helidonVersion";
+    protected static int defaultMinJavaMajorVersion = 17;
 
     private String library;
     private String generatorName;
@@ -143,6 +145,11 @@ abstract class FunctionalBase {
         ProcessReader process = runMavenProcess(args);
         process.waitFor(10, TimeUnit.MINUTES);
         return process;
+    }
+
+    protected int getCurrentJavaMajorVersion() {
+        String[] versionElements = System.getProperty("java.version").split("\\.");
+        return Integer.parseInt(versionElements[0]);
     }
 
     /**
@@ -251,10 +258,25 @@ abstract class FunctionalBase {
 
     /**
      * Convenience method to build project using Maven and verify test output.
+     * <p>
+     * Minimal major java version for execution of this test will be equal to {@value #defaultMinJavaMajorVersion}
      *
      * @param jarPath path to expected jar file
      */
     protected void buildAndVerify(String jarPath) {
+        buildAndVerify(jarPath, defaultMinJavaMajorVersion);
+    }
+
+    /**
+     * Convenience method to build project using Maven and verify test output.
+     *
+     * @param jarPath path to expected jar file
+     * @param minRequiredJavaVersion minimal major java version to build project and run test
+     */
+    protected void buildAndVerify(String jarPath, int minRequiredJavaVersion) {
+        if (getCurrentJavaMajorVersion() < minRequiredJavaVersion) {
+            return;
+        }
         ProcessReader reader = runMavenProcessAndWait("package");
         Path executableJar = outputPath.resolve(jarPath);
         String output = reader.readOutputConsole();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/functional/FunctionalHelidonSeServerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/helidon/functional/FunctionalHelidonSeServerTest.java
@@ -48,6 +48,13 @@ public class FunctionalHelidonSeServerTest extends FunctionalBase {
     }
 
     @Test
+    void buildPetstoreWithHelidonVersion2() {
+        inputSpec("src/test/resources/3_0/petstore.yaml");
+        generate(createConfigurator().addAdditionalProperty(FunctionalBase.HELIDON_VERSION, "2.5.2"));
+        buildAndVerify("target/openapi-java-server.jar", 11);
+    }
+
+    @Test
     void verifyFullProject() {
         inputSpec("src/test/resources/3_0/petstore.yaml");
 


### PR DESCRIPTION
Fix issues related to Json provider in Helidon SE server generator and java version issue in FunctionalTest : 
- change root EE package for Json provider when Helidon version is changing in Helidon SE server generator
- check minimal required java version in functional tests before building test projects

Resolves #https://github.com/helidon-io/helidon/issues/4925