### PR TITLE
Add Helidon samples to JDK17 samples workflow

### DIFF
--- a/.github/workflows/samples-jdk17.yaml
+++ b/.github/workflows/samples-jdk17.yaml
@@ -4,14 +4,22 @@ on:
     paths:
       # clients
       - samples/openapi3/client/petstore/spring-cloud-3
+      - samples/client/petstore/java-helidon-client/mp
+      - samples/client/petstore/java-helidon-client/se
       # servers
       - samples/openapi3/server/petstore/springboot-3
+      - samples/server/petstore/java-helidon-server/mp
+      - samples/server/petstore/java-helidon-server/se
   pull_request:
     paths:
       # clients
       - samples/openapi3/client/petstore/spring-cloud-3
+      - samples/client/petstore/java-helidon-client/mp
+      - samples/client/petstore/java-helidon-client/se
       # servers
       - samples/openapi3/server/petstore/springboot-3
+      - samples/server/petstore/java-helidon-server/mp
+      - samples/server/petstore/java-helidon-server/se
 jobs:
   build:
     name: Build with JDK17
@@ -22,8 +30,12 @@ jobs:
         sample:
           # clients
           - samples/openapi3/client/petstore/spring-cloud-3
+          - samples/client/petstore/java-helidon-client/mp
+          - samples/client/petstore/java-helidon-client/se
           # servers
           - samples/openapi3/server/petstore/springboot-3
+          - samples/server/petstore/java-helidon-server/mp
+          - samples/server/petstore/java-helidon-server/se
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3


### PR DESCRIPTION
At William's request, adding the new Helidon samples to the JDK 17 workflow.

Signed-off-by: tim.quinn@oracle.com <tim.quinn@oracle.com>
